### PR TITLE
Implement token versioning for efficient invalidation

### DIFF
--- a/Server/src/db/migrations/20250502121528-add-token-version.js
+++ b/Server/src/db/migrations/20250502121528-add-token-version.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // Add tokenVersion column to users table
+    await queryInterface.addColumn('users', 'tokenVersion', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('users', 'tokenVersion');
+  }
+};

--- a/Server/src/models/user.js
+++ b/Server/src/models/user.js
@@ -29,15 +29,15 @@ module.exports = (sequelize) => {
       allowNull: false
     },
     salt: {
-      type: DataTypes.STRING(60),
+      type: DataTypes.STRING(64),
       allowNull: false
     },
     encryptedDEK: {
-      type: DataTypes.STRING(44),
+      type: DataTypes.TEXT,
       allowNull: false
     },
     dekIV: {
-      type: DataTypes.STRING(32), // Increased from 24 to 32
+      type: DataTypes.STRING(64),
       allowNull: false
     },
     lastUpdate: {
@@ -51,6 +51,12 @@ module.exports = (sequelize) => {
     keyCreationDate: {
       type: DataTypes.DATE,
       defaultValue: DataTypes.NOW
+    },
+    // Add token version to track password changes
+    tokenVersion: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0
     }
   }, {
     sequelize,


### PR DESCRIPTION
This PR implements token versioning as a solution for token invalidation without relying on blacklists. The key changes include:

- Added `tokenVersion` field to user table (with migration)
- Modified token generation to include user's current token version
- Updated token validation to verify version against user's current version

This approach allows us to invalidate all tokens for a user by simply incrementing their token version, which is significantly more efficient than maintaining blacklists of invalidated tokens. It also ensures immediate invalidation across all devices when a user logs out.

Fixes #2 